### PR TITLE
DE-100 | Resolve sasl dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ setup(
         'pandas>=1.0.0',
         'pyhive>=0.6.1',
         'river>=0.1.1'  # Must configure NHDS PyPi as an external url for pip
-        'sasl>=0.2.1'
     ],
     cmdclass={
         'upload': UploadCommand,


### PR DESCRIPTION
Looked into `pyhive`'s `sasl` dependency. Turns out, the `sasl` package is just one of those things that kind of gets lost in google, because so many varieties of it are around. The dependency is already fully handled by `pyhive`'s specifications under the hood, so it can be removed from `setup.py`.