### PR TITLE
DE-129/etc | Fix problematic dtypes

### DIFF
--- a/honeycomb/append_table.py
+++ b/honeycomb/append_table.py
@@ -1,7 +1,6 @@
 import river as rv
 
 from honeycomb import check, meta
-from honeycomb.dtype_mapping import handle_problematic_dtypes
 
 
 def append_table(df, table_name, schema='experimental', filename=None):
@@ -41,6 +40,5 @@ def append_table(df, table_name, schema='experimental', filename=None):
                        'Which will be overwritten by this operation. '
                        'Specify a different filename to proceed.')
 
-    df = handle_problematic_dtypes(df)
     storage_settings = meta.storage_type_specs[storage_type]['settings']
     rv.write(df, path, bucket, **storage_settings)

--- a/honeycomb/create_table.py
+++ b/honeycomb/create_table.py
@@ -4,8 +4,7 @@ import subprocess
 import river as rv
 
 from honeycomb import check, meta, run_query as run
-from honeycomb.dtype_mapping import (
-    apply_spec_dtypes, map_pd_to_db_dtypes, handle_problematic_dtypes)
+from honeycomb.dtype_mapping import apply_spec_dtypes, map_pd_to_db_dtypes
 
 
 schema_to_zone_bucket_map = {
@@ -184,8 +183,6 @@ def create_table_from_df(df, table_name, schema='experimental',
     col_defs = map_pd_to_db_dtypes(df)
     if col_comments is not None:
         col_defs = add_comments_to_col_defs(col_defs, col_comments)
-
-    df = handle_problematic_dtypes(df)
 
     storage_type = os.path.splitext(filename)[-1][1:].lower()
     storage_settings = meta.storage_type_specs[storage_type]['settings']

--- a/honeycomb/dtype_mapping.py
+++ b/honeycomb/dtype_mapping.py
@@ -11,7 +11,7 @@ dtype_map = {
     'int64': 'INT',
     'float64': 'DOUBLE',
     'bool': 'BOOLEAN',
-    'datetime64[ns]': 'STRING',
+    'datetime64[ns]': 'TIMESTAMP',
 }
 
 
@@ -63,11 +63,3 @@ def map_pd_to_db_dtypes(df):
         db_dtypes[db_dtypes == orig_type] = new_type
 
     return db_dtypes
-
-
-def handle_problematic_dtypes(df):
-    # Datetime
-    datetime_cols = df.columns[df.dtypes == 'datetime64[ns]']
-    df[datetime_cols] = df[datetime_cols].apply(
-        lambda x: x.dt.strftime('%y-%m-%d %H:%M:%S'))
-    return df

--- a/honeycomb/meta.py
+++ b/honeycomb/meta.py
@@ -17,7 +17,8 @@ storage_type_specs = {
     'pq': {
         'settings': {
             'engine': 'pyarrow',
-            'compression': 'snappy'
+            'compression': 'snappy',
+            'use_deprecated_int96_timestamps': True
         },
         'ddl': 'STORED AS PARQUET'
     }


### PR DESCRIPTION
1. It turns out that hive only supports the `INTERVAL` type for returned values from a query, _not_ as a dtype of an entire column of a table. In other words, conversion of `timedelta`s within `honeycomb` is unnecessary, because hive won't allow them anyway.

2. Turns out hive's `DATETIME` dtype isn't fully supported yet. Switched it to `TIMESTAMP` - should have no real effect on us.

3. While testing this, I changed the table creation logic to write to S3 _after_ creating the table. This way, if creation of a table fails, we won't have stray files in S3.