### PR TITLE
DE-225 | Enhanced CTAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ were, as mentioned above, using different underlying storage formats.
 both Parquet or both Avro - `hive` would, for currently unknown reasons, fail to
 disable vectorization, and it would attempt to run a non-vectorizable
 query as vectorized.
+- Hive ticket created here: https://issues.apache.org/jira/browse/HIVE-24647#
 
 ## [1.5.0] - 2021-01-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CTAS functionality now works with `JOIN` queries that involve complex columns
+
+### Notes
+- Discovered a `hive` bug, in v3.1.2. Performing queries that `SELECT` complex-type columns from a
+`JOIN` clause only works if the two tables are of different underlying file types -
+in the context of filetypes that `honeycomb` supports complex type columns with,
+that would mean one table using Avro, and the other using Parquet.
+- This is because `hive` attempts to run the query as vectorized when it should not.
+- Query vectorization in `hive` only works on queries that exclusively involve
+primitive-type columns. If `hive` sees that a complex-type column is
+involved in a query, it is supposed to disable vectorization for that query.
+- When the query involves a `JOIN`, it will properly do so if the tables
+were, as mentioned above, using different underlying storage formats.
+- If the tables are using the same storage format though - for `honeycomb`,
+both Parquet or both Avro - `hive` would, for currently unknown reasons, fail to
+disable vectorization, and it would attempt to run a non-vectorizable
+query as vectorized.
+
 ## [1.5.0] - 2021-01-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ a result the average use case of it is very straightforward.
         2. Salesforce - Runs against data stored in the Salesforce Object Manager.
         NOTE: Salesforce uses SOQL, which has different syntax than the lake.
         ```
-        from honeycomb.salesforce import run_sf_query, sf_select_star
+        from honeycomb import salesforce as hcsf
 
         query = "SELECT Id FROM Lead LIMIT 5"
-        df = run_sf_query(query)
+        df = hcsf.run_sf_query(query)
 
-        df_star = sf_select_star(object_name='Lead',
+        df_star = hcsf.sf_select_star(object_name='Lead',
                                  where_clause='WHERE CreatedDate <= 2020-08-01T00:00-00:00',
                                  limit_clause='LIMIT 5')
         ```

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ a result the average use case of it is very straightforward.
         df = hcsf.run_sf_query(query)
 
         df_star = hcsf.sf_select_star(object_name='Lead',
-                                 where_clause='WHERE CreatedDate <= 2020-08-01T00:00-00:00',
-                                 limit_clause='LIMIT 5')
+                                      where_clause='WHERE CreatedDate <= 2020-08-01T00:00-00:00',
+                                      limit_clause='LIMIT 5')
         ```
 
 ### Running Queries

--- a/honeycomb/connection.py
+++ b/honeycomb/connection.py
@@ -1,7 +1,8 @@
 from pyhive import hive, presto
 
 
-def get_db_connection(engine='hive', addr='localhost', cursor=True):
+def get_db_connection(engine='hive', addr='localhost', cursor=True,
+                      configuration=None):
     """
     Initializes and returns a connection to the specified database engine.
 
@@ -16,12 +17,16 @@ def get_db_connection(engine='hive', addr='localhost', cursor=True):
         port = 10000
         engine_module = hive
     elif engine == 'presto':
+        if configuration is not None:
+            raise ValueError(
+                'Non-default configurations with Presto are not supported.')
         port = 8889
         engine_module = presto
     else:
         raise ValueError('Specified engine is not supported: ' + engine)
 
-    conn = engine_module.connect(addr, port=port, username='hadoop')
+    conn = engine_module.connect(addr, port=port, username='hadoop',
+                                 configuration=configuration)
     if cursor:
         conn = conn.cursor()
     return conn

--- a/honeycomb/create_table.py
+++ b/honeycomb/create_table.py
@@ -337,13 +337,17 @@ def ctas(select_stmt, table_name, schema=None,
                 table_comment, col_defs['col_name'], col_comments)
 
         create_table_ddl = build_create_table_ddl(table_name, schema, col_defs,
-                                                  full_path, storage_type)
+                                                  col_comments, table_comment,
+                                                  storage_type,
+                                                  partitioned_by=None,
+                                                  full_path=full_path)
         handle_existing_table(table_name, schema, overwrite)
         hive.run_lake_query(create_table_ddl)
         insert_overwrite_command = (
             'INSERT OVERWRITE TABLE {}.{} SELECT * FROM {}.{}').format(
                 schema, table_name, temp_schema, view_name)
-        hive.run_lake_query(insert_overwrite_command)
+        hive.run_lake_query(insert_overwrite_command,
+                            has_complex_cols_and_joins=True)
     finally:
         hive.run_lake_query('DROP VIEW {}.{}'.format(temp_schema, view_name))
 

--- a/honeycomb/create_table.py
+++ b/honeycomb/create_table.py
@@ -325,6 +325,11 @@ def ctas(select_stmt, table_name, schema=None,
     """
     if schema != 'experimental':
         check_for_allowed_overwrite(overwrite)
+    if schema == 'curated' and not os.getenv('HC_PROD_ENV'):
+        raise ValueError(
+            'CTAS functionality is currently disabled in the curated zone. '
+            'Contact Data Engineering for further information.'
+        )
 
     bucket = schema_to_zone_bucket_map[schema]
     path = validate_table_path(path, table_name)

--- a/honeycomb/create_table.py
+++ b/honeycomb/create_table.py
@@ -347,7 +347,7 @@ def ctas(select_stmt, table_name, schema=None,
             'INSERT OVERWRITE TABLE {}.{} SELECT * FROM {}.{}').format(
                 schema, table_name, temp_schema, view_name)
         hive.run_lake_query(insert_overwrite_command,
-                            has_complex_cols_and_joins=True)
+                            complex_join=True)
     finally:
         hive.run_lake_query('DROP VIEW {}.{}'.format(temp_schema, view_name))
 

--- a/honeycomb/create_table.py
+++ b/honeycomb/create_table.py
@@ -327,8 +327,8 @@ def ctas(select_stmt, table_name, schema=None,
         check_for_allowed_overwrite(overwrite)
     if schema == 'curated' and not os.getenv('HC_PROD_ENV'):
         raise ValueError(
-            'CTAS functionality is currently disabled in the curated zone. '
-            'Contact Data Engineering for further information.'
+            'Non-production CTAS functionality is currently disabled in the '
+            'curated zone. Contact Data Engineering for further information.'
         )
 
     bucket = schema_to_zone_bucket_map[schema]

--- a/honeycomb/create_table.py
+++ b/honeycomb/create_table.py
@@ -262,12 +262,22 @@ def get_storage_type_from_filename(filename):
 
 def prep_df_and_col_defs(df, dtypes, timezones, schema,
                          storage_type):
+    """
+    Applies any specified dtypes to df and any special handling that certain
+    data types require. Also creates a mapping from the df's pandas dtypes
+    to the corresponding hive dtypes
+    """
     df = dtype_mapping.special_dtype_handling(df, dtypes, timezones, schema)
     col_defs = dtype_mapping.map_pd_to_db_dtypes(df, storage_type)
     return df, col_defs
 
 
 def handle_avro_filetype(df, storage_settings, tblproperties, avro_schema):
+    """
+    Special behavior for DataFrames to be saved in the Avro format.
+    Generates the Avro schema once and uses it twice, to avoid
+    needing two separate generation processes.
+    """
     if avro_schema is None:
         avro_schema = pdx.schema_infer(df)
     tblproperties['avro.schema.literal'] = pprint.pformat(

--- a/honeycomb/create_table.py
+++ b/honeycomb/create_table.py
@@ -104,11 +104,9 @@ def create_table_from_df(df, table_name, schema=None,
 
     handle_existing_table(table_name, schema, overwrite)
 
-    path = validate_table_path(path, table_name)
-
     if filename is None:
         filename = meta.gen_filename_if_allowed(schema)
-    path = meta.ensure_path_ends_w_slash(path)
+    path = validate_table_path(path, table_name)
 
     bucket = schema_to_zone_bucket_map[schema]
 
@@ -179,6 +177,7 @@ def handle_existing_table(table_name, schema, overwrite):
 def validate_table_path(path, table_name):
     if path is None:
         path = table_name
+    path = meta.ensure_path_ends_w_slash(path)
     if not re.match(r'^\w+/$', path, flags=re.ASCII):
         raise ValueError('Invalid table path provided.')
     return path

--- a/honeycomb/hive.py
+++ b/honeycomb/hive.py
@@ -9,7 +9,7 @@ col_prefix_regex = r'^.*\.'
 hive_vector_option_name = 'hive.vectorized.execution.enabled'
 
 
-def run_lake_query(query, engine='hive', has_complex_cols_and_joins=False):
+def run_lake_query(query, engine='hive', complex_join=False):
     """
     General wrapper function around querying with different engines
 
@@ -19,13 +19,13 @@ def run_lake_query(query, engine='hive', has_complex_cols_and_joins=False):
             The querying engine to run the query through
             Use 'presto' for faster, ad-hoc/experimental querie
             Use 'hive' for slower but more robust queries
-        has_complex_cols_and_joins (bool, default False):
+        complex_join (bool, default False):
             Whether the query involves both complex cols and joins. Indicating
             this beforehand will save query time later, as it allows for
             avoiding error handling associated with running a query like that
             without special treatment. Caused by a hive bug
     """
-    if has_complex_cols_and_joins:
+    if complex_join:
         configuration = _hive_get_nonvectorized_config()
     else:
         configuration = None
@@ -154,8 +154,8 @@ def _hive_check_if_complex_join_error(query, addr, configuration,
                  'Query involves selecting complex type columns from a '
                  'joined table. Due to a hive bug, extra options must be '
                  'set for this scenario. To speed up query time, set '
-                 '\'has_complex_cols_and_joins\' to True in '
-                 '\'hc.run_lake_query\'if you run such a query again.'
+                 '\'complex_join\' to True in \'hc.run_lake_query\' '
+                 'if you run such a query again.'
             )
             print(disabling_vectorization_msg)
             configuration = _hive_get_nonvectorized_config(configuration)

--- a/honeycomb/hive.py
+++ b/honeycomb/hive.py
@@ -5,7 +5,13 @@ import pandas as pd
 from honeycomb.connection import get_db_connection
 
 
-def run_lake_query(query, engine='hive', configuration=None):
+col_prefix_regex = r'^.*\.'
+
+hive_vector_option_name = 'hive.vectorized.execution.enabled'
+false_str = 'false'
+
+
+def run_lake_query(query, engine='hive', has_complex_cols_and_joins=False):
     """
     General wrapper function around querying with different engines
 
@@ -15,7 +21,17 @@ def run_lake_query(query, engine='hive', configuration=None):
             The querying engine to run the query through
             Use 'presto' for faster, ad-hoc/experimental querie
             Use 'hive' for slower but more robust queries
+        has_complex_cols_and_joins (bool, default False):
+            Whether the query involves both complex cols and joins. Indicating
+            this beforehand will save query time later, as it allows for
+            avoiding error handling associated with running a query like that
+            without special treatment. Caused by a hive bug
     """
+    if has_complex_cols_and_joins:
+        configuration = {hive_vector_option_name: false_str}
+    else:
+        configuration = None
+
     addr = os.getenv('HC_LAKE_ADDRESS', 'localhost')
 
     query_fns = {
@@ -43,38 +59,81 @@ def _hive_query(query, addr, configuration):
     Hive-specific query function
     Note: uses an actual connection, rather than a connection cursor
     """
-    col_prefix_regex = r'^.*\.'
     if _query_returns_df(query):
-        try:
-            with get_db_connection('hive', addr=addr, cursor=False,
-                                   configuration=configuration) as conn:
+        if 'join' in query.lower():
+            df = _hive_handle_join_query(query, addr, configuration)
 
-                df = pd.read_sql(query, conn)
-        except pd.io.sql.DatabaseError as e:
-            complex_col_err_substring = (
-                'cannot be cast to org.apache.hadoop.'
-                'hive.serde2.objectinspector.PrimitiveObjectInspector'
-            )
-            if complex_col_err_substring in e.args[0]:
-
-        if 'join' not in query.lower():
+        else:
+            df = _hive_run_pd_query_w_context(query, addr, configuration)
             # Cleans table prefixes from all column names,
             # which are added by Hive even in non-join queries
             df.columns = df.columns.str.replace(col_prefix_regex, '')
-        else:
-            # Cleans table prefixes from any non-duplicated column names
-            cols_wo_prefix = df.columns.str.replace(col_prefix_regex, '')
-            duplicated_cols = cols_wo_prefix.duplicated(keep=False)
-            cols_to_rename = dict(zip(df.columns[~duplicated_cols],
-                                      cols_wo_prefix[~duplicated_cols]))
 
-            df = df.rename(columns=cols_to_rename)
-
-            return df
+        return df
     else:
         with get_db_connection('hive', addr=addr, cursor=True,
                                configuration=configuration) as conn:
             conn.execute(query)
+
+
+def _hive_handle_join_query(query, addr, configuration):
+    """
+    Applies the special behaviors needed for queries involving
+    the `JOIN` keyword
+
+    Currently, due to a bug in hive 3.1.2, `JOIN` queries if the underlying
+    storage types of the involved tables are the same and complex-type columns
+    are involved. This is because hive is supposed to disable query
+    vectorization if complex columns are involved, but for some reason this
+    is not applied on JOINs involving tables of the same storage type
+
+    1. If the user did not specify that complex columns were involved in
+       the query, this function will catch the related error and retry
+       with vectorization manually disabled.
+    2. This function also removes the prefixed table name from all column names
+       except those that would have a naming conflict post-join
+    """
+    try:
+        df = _hive_run_pd_query_w_context(query, addr, configuration)
+
+    except pd.io.sql.DatabaseError as e:
+
+        if (isinstance(configuration, dict) and
+                configuration[hive_vector_option_name] == 'true'):
+            # This means that the query failed even though vectorization
+            # was disabled, and the failure is caused by something else
+            raise e
+
+        complex_col_err_substring = (
+            'cannot be cast to org.apache.hadoop.'
+            'hive.serde2.objectinspector.PrimitiveObjectInspector'
+        )
+        if complex_col_err_substring in e.args[0]:
+            print('Query involves selecting complex type columns from a '
+                  'joined table. Due to a hive bug, extra options must be '
+                  'set for this scenario. To speed up query time, set '
+                  '\'has_complex_cols_and_joins\' to True in '
+                  '\'hc.run_lake_query\'if you run such a query again.')
+            configuration[hive_vector_option_name] = false_str
+            return _hive_handle_join_query(query, addr, configuration)
+
+    # Cleans table prefixes from any non-duplicated column names
+    cols_wo_prefix = df.columns.str.replace(col_prefix_regex, '')
+    duplicated_cols = cols_wo_prefix.duplicated(keep=False)
+    cols_to_rename = dict(zip(df.columns[~duplicated_cols],
+                              cols_wo_prefix[~duplicated_cols]))
+
+    df = df.rename(columns=cols_to_rename)
+
+    return df
+
+
+def _hive_run_pd_query_w_context(query, addr, configuration):
+    """Runs a hive query within a connection context manager"""
+    with get_db_connection('hive', addr=addr, cursor=False,
+                           configuration=configuration) as conn:
+        df = pd.read_sql(query, conn)
+    return df
 
 
 def _presto_query(query, addr, configuration):

--- a/honeycomb/hive.py
+++ b/honeycomb/hive.py
@@ -89,7 +89,8 @@ def _hive_handle_join_query(query, addr, configuration):
 
     1. If the user did not specify that complex columns were involved in
        the query, this function will catch the related error and retry
-       with vectorization manually disabled.
+       with vectorization manually disabled. If a query fails for a different
+       reason than expected, the error will be raised normally
     2. This function also removes the prefixed table name from all column names
        except those that would have a naming conflict post-join
     """
@@ -140,6 +141,10 @@ def _presto_query(query, addr, configuration):
     """
     Presto-specific query function
     Note: uses an actual connection, rather than a connection cursor
+
+    The 'configuration' parameter is included solely as a pass-through for
+    compatibility reasons. If it is not 'None' it will raise errors in
+    get_db_connection
     """
     # Presto does not have a notion of a persistent connection, so closing
     # is unnecessary

--- a/honeycomb/hive.py
+++ b/honeycomb/hive.py
@@ -6,9 +6,7 @@ from honeycomb.connection import get_db_connection
 
 
 col_prefix_regex = r'^.*\.'
-
 hive_vector_option_name = 'hive.vectorized.execution.enabled'
-false_str = 'false'
 
 
 def run_lake_query(query, engine='hive', has_complex_cols_and_joins=False):
@@ -28,7 +26,7 @@ def run_lake_query(query, engine='hive', has_complex_cols_and_joins=False):
             without special treatment. Caused by a hive bug
     """
     if has_complex_cols_and_joins:
-        configuration = {hive_vector_option_name: false_str}
+        configuration = _hive_get_nonvectorized_config()
     else:
         configuration = None
 
@@ -41,6 +39,15 @@ def run_lake_query(query, engine='hive', has_complex_cols_and_joins=False):
     query_fn = query_fns[engine]
     df = query_fn(query, addr, configuration)
     return df
+
+
+def _hive_get_nonvectorized_config(configuration=None):
+    false_str = 'false'
+    if isinstance(configuration, dict):
+        configuration[hive_vector_option_name] = false_str
+    else:
+        configuration = {hive_vector_option_name: false_str}
+    return configuration
 
 
 def _query_returns_df(query):
@@ -59,82 +66,102 @@ def _hive_query(query, addr, configuration):
     Hive-specific query function
     Note: uses an actual connection, rather than a connection cursor
     """
+    is_join_query = 'join' in query.lower()
     if _query_returns_df(query):
-        if 'join' in query.lower():
-            df = _hive_handle_join_query(query, addr, configuration)
-
-        else:
-            df = _hive_run_pd_query_w_context(query, addr, configuration)
-            # Cleans table prefixes from all column names,
-            # which are added by Hive even in non-join queries
-            df.columns = df.columns.str.replace(col_prefix_regex, '')
-
-        return df
+        conn = get_db_connection('hive', addr=addr, cursor=False,
+                                 configuration=configuration)
+        kwargs = {'sql': query, 'con': conn}
+        query_fn = pd.read_sql
+        should_return_df = True
     else:
-        with get_db_connection('hive', addr=addr, cursor=True,
-                               configuration=configuration) as conn:
-            conn.execute(query)
+        conn = get_db_connection('hive', addr=addr, cursor=True,
+                                 configuration=configuration)
+        kwargs = {'operation': query}
+        query_fn = conn.execute
+        should_return_df = False
 
-
-def _hive_handle_join_query(query, addr, configuration):
-    """
-    Applies the special behaviors needed for queries involving
-    the `JOIN` keyword
-
-    Currently, due to a bug in hive 3.1.2, `JOIN` queries if the underlying
-    storage types of the involved tables are the same and complex-type columns
-    are involved. This is because hive is supposed to disable query
-    vectorization if complex columns are involved, but for some reason this
-    is not applied on JOINs involving tables of the same storage type
-
-    1. If the user did not specify that complex columns were involved in
-       the query, this function will catch the related error and retry
-       with vectorization manually disabled. If a query fails for a different
-       reason than expected, the error will be raised normally
-    2. This function also removes the prefixed table name from all column names
-       except those that would have a naming conflict post-join
-    """
     try:
-        df = _hive_run_pd_query_w_context(query, addr, configuration)
-
+        df = query_fn(**kwargs)
     except pd.io.sql.DatabaseError as e:
+        return _hive_check_if_complex_join_error(query, addr, configuration,
+                                                 e, is_join_query)
 
-        if (isinstance(configuration, dict) and
-                configuration[hive_vector_option_name] == 'true'):
-            # This means that the query failed even though vectorization
-            # was disabled, and the failure is caused by something else
-            raise e
+    if should_return_df:
+        if not is_join_query:
+            df.columns = df.columns.str.replace(col_prefix_regex, '')
+        else:
+            # Cleans table prefixes from any non-duplicated column names
+            cols_wo_prefix = df.columns.str.replace(col_prefix_regex, '')
+            duplicated_cols = cols_wo_prefix.duplicated(keep=False)
+            cols_to_rename = dict(zip(df.columns[~duplicated_cols],
+                                      cols_wo_prefix[~duplicated_cols]))
 
-        complex_col_err_substring = (
+            df = df.rename(columns=cols_to_rename)
+        return df
+
+
+def _hive_check_if_complex_join_error(query, addr, configuration,
+                                      e, is_join_query):
+    """
+    Checks if an error raised by _hive_query is the error caused by a hive bug
+    where non-vectorizable queries being run as vectorized (described below).
+    If the user did not specify that complex columns were involved in
+    the query using 'complex_join=True', this function will catch the
+    related error and retry with vectorization manually disabled. If a query
+    fails for a different reason than expected, the error will be
+    raised normally
+
+    Currently, due to a bug in hive 3.1.2, `JOIN` queries raise errors if the
+    underlying storage types of the involved tables are the same and
+    complex-type columns are being selected. This is because hive is supposed
+    to disable query vectorization if complex columns are involved, but for
+    some reason this is not applied on JOINs involving tables of the same
+    storage type. This is seen in honeycomb if both tables use Parquet or
+    both use Avro
+
+    Args:
+        query (str): The query to be run
+        addr (str): The address of the data lake to communicate with
+        configuration (dict<str:str>):
+            Optional settings to apply to the hive connection
+        e (Exception): The exception raised by _hive_query
+        is_join_query (bool):
+            Whether the query being run involves JOINing. If it is not,
+            then the original exception is immediately re-raised, as it
+            is definitively not the error we are trying to catch.
+    """
+    if is_join_query:
+        # This means that the query failed even though vectorization
+        # was disabled, and the failure is caused by something else
+        already_attempted_nonvectorization = (
+            isinstance(configuration, dict) and
+            configuration[hive_vector_option_name] == 'true')
+
+        complex_join_err_substring = (
             'cannot be cast to org.apache.hadoop.'
             'hive.serde2.objectinspector.PrimitiveObjectInspector'
         )
-        if complex_col_err_substring in e.args[0]:
-            print('Query involves selecting complex type columns from a '
-                  'joined table. Due to a hive bug, extra options must be '
-                  'set for this scenario. To speed up query time, set '
-                  '\'has_complex_cols_and_joins\' to True in '
-                  '\'hc.run_lake_query\'if you run such a query again.')
-            configuration[hive_vector_option_name] = false_str
-            return _hive_handle_join_query(query, addr, configuration)
 
-    # Cleans table prefixes from any non-duplicated column names
-    cols_wo_prefix = df.columns.str.replace(col_prefix_regex, '')
-    duplicated_cols = cols_wo_prefix.duplicated(keep=False)
-    cols_to_rename = dict(zip(df.columns[~duplicated_cols],
-                              cols_wo_prefix[~duplicated_cols]))
+        # This means the error raised matches that which is raised from
+        # queries involving complex columns and table joining
+        is_complex_join_err = complex_join_err_substring in e.args[0]
 
-    df = df.rename(columns=cols_to_rename)
-
-    return df
-
-
-def _hive_run_pd_query_w_context(query, addr, configuration):
-    """Runs a hive query within a connection context manager"""
-    with get_db_connection('hive', addr=addr, cursor=False,
-                           configuration=configuration) as conn:
-        df = pd.read_sql(query, conn)
-    return df
+        # If the query has both not already been attempted with vectorization
+        # disabled and the raised does contain the substring that is indicitave
+        # of the error raised by the hive bug
+        if not already_attempted_nonvectorization and is_complex_join_err:
+            disabling_vectorization_msg = (
+                 'Query involves selecting complex type columns from a '
+                 'joined table. Due to a hive bug, extra options must be '
+                 'set for this scenario. To speed up query time, set '
+                 '\'has_complex_cols_and_joins\' to True in '
+                 '\'hc.run_lake_query\'if you run such a query again.'
+            )
+            print(disabling_vectorization_msg)
+            configuration = _hive_get_nonvectorized_config(configuration)
+            return _hive_query(query, addr, configuration)
+    else:
+        raise pd.io.sql.DataBaseError() from e
 
 
 def _presto_query(query, addr, configuration):


### PR DESCRIPTION
### Changed
- CTAS functionality now works with `JOIN` queries that involve complex columns

### Notes
- Discovered a `hive` bug, in v3.1.2. Performing queries that `SELECT` complex-type columns from a
`JOIN` clause only works if the two tables are of different underlying file types -
in the context of filetypes that `honeycomb` supports complex type columns with,
that would mean one table using Avro, and the other using Parquet.
- This is because `hive` attempts to run the query as vectorized when it should not.
- Query vectorization in `hive` only works on queries that exclusively involve
primitive-type columns. If `hive` sees that a complex-type column is
involved in a query, it is supposed to disable vectorization for that query.
- When the query involves a `JOIN`, it will properly do so if the tables
were, as mentioned above, using different underlying storage formats.
- If the tables are using the same storage format though - for `honeycomb`,
both Parquet or both Avro - `hive` would, for currently unknown reasons, fail to
disable vectorization, and it would attempt to run a non-vectorizable
query as vectorized.