### PR TITLE
v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.5.1] - 2021-01-20
 
 ### Changed
 - Bugfix: CTAS functionality now works with `JOIN` queries that involve complex columns
+- Bugfix: `INSERT OVERWRITE` commands are now prevented from overwriting the entirety of a bucket
 - Bugfix: `_query_returns_df` now properly identifies query types even when
 the query contains leading whitespace
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.5.1] - 2021-01-20
 
 ### Changed

--- a/honeycomb/_version.py
+++ b/honeycomb/_version.py
@@ -1,6 +1,6 @@
 __title__ = "honeycomb"
 __description__ = "Multi-source/engine querying tool"
 __url__ = "https://github.com/neighborhoods/honeycomb"
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 __author__ = "George Wood (@Geoiv)"
 __author_email__ = "george.wood@55places.com"


### PR DESCRIPTION
### Changed
- Bugfix: CTAS functionality now works with `JOIN` queries that involve complex columns
- Bugfix: `INSERT OVERWRITE` commands are now prevented from overwriting the entirety of a bucket
- Bugfix: `_query_returns_df` now properly identifies query types even when
the query contains leading whitespace