### PR TITLE
v1.5.2 / Only block overwrite in Curated Zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.5.1] - 2021-01-20
 
 ### Changed
 - Bugfix: CTAS functionality now works with `JOIN` queries that involve complex columns
+- Bugfix: `INSERT OVERWRITE` commands are now prevented from overwriting the entirety of a bucket
 - Bugfix: `_query_returns_df` now properly identifies query types even when
 the query contains leading whitespace
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2] - 2021-01-22
+
+### Changed
+- Only enforce overwrite protection on the Curated zone, as opposed to all non-Experimental zones
+
 ## [1.5.1] - 2021-01-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.5.1] - 2021-01-20
 
 ### Changed

--- a/honeycomb/_version.py
+++ b/honeycomb/_version.py
@@ -1,6 +1,6 @@
 __title__ = "honeycomb"
 __description__ = "Multi-source/engine querying tool"
 __url__ = "https://github.com/neighborhoods/honeycomb"
-__version__ = "1.5.1"
+__version__ = "1.5.2"
 __author__ = "George Wood (@Geoiv)"
 __author_email__ = "george.wood@55places.com"

--- a/honeycomb/_version.py
+++ b/honeycomb/_version.py
@@ -1,6 +1,6 @@
 __title__ = "honeycomb"
 __description__ = "Multi-source/engine querying tool"
 __url__ = "https://github.com/neighborhoods/honeycomb"
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 __author__ = "George Wood (@Geoiv)"
 __author_email__ = "george.wood@55places.com"

--- a/honeycomb/create_table.py
+++ b/honeycomb/create_table.py
@@ -324,7 +324,7 @@ def ctas(select_stmt, table_name, schema=None,
     """
     if schema == 'curated':
         check_for_allowed_overwrite(overwrite)
-        if  not os.getenv('HC_PROD_ENV'):
+        if not os.getenv('HC_PROD_ENV'):
             raise ValueError(
                 'Non-production CTAS functionality is currently disabled in '
                 'the curated zone. Contact Data Engineering for '

--- a/honeycomb/create_table.py
+++ b/honeycomb/create_table.py
@@ -346,7 +346,7 @@ def ctas(select_stmt, table_name, schema=None,
     try:
         col_defs = describe_table(view_name, schema=temp_schema)
 
-        if schema != 'experimental':
+        if schema == 'curated':
             check_for_comments(
                 table_comment, col_defs['col_name'], col_comments)
 

--- a/honeycomb/create_table.py
+++ b/honeycomb/create_table.py
@@ -98,7 +98,7 @@ def create_table_from_df(df, table_name, schema=None,
                 'If using "partitioned_by" and "auto_upload_df" is True, '
                 'values must be passed to "partition_values" as well.')
 
-    if schema != 'experimental':
+    if schema == 'curated':
         check_for_comments(table_comment, df.columns, col_comments)
         check_for_allowed_overwrite(overwrite)
 
@@ -322,13 +322,14 @@ def ctas(select_stmt, table_name, schema=None,
             Whether to overwrite or fail if a table already exists with
             the intended name of the new table in the selected schema
     """
-    if schema != 'experimental':
+    if schema == 'curated':
         check_for_allowed_overwrite(overwrite)
-    if schema == 'curated' and not os.getenv('HC_PROD_ENV'):
-        raise ValueError(
-            'Non-production CTAS functionality is currently disabled in the '
-            'curated zone. Contact Data Engineering for further information.'
-        )
+        if  not os.getenv('HC_PROD_ENV'):
+            raise ValueError(
+                'Non-production CTAS functionality is currently disabled in '
+                'the curated zone. Contact Data Engineering for '
+                'further information.'
+            )
 
     bucket = schema_to_zone_bucket_map[schema]
     path = validate_table_path(path, table_name)
@@ -401,7 +402,7 @@ def flash_update_table_from_df(df, table_name, schema=None, dtypes=None,
 
     table_name, schema = meta.prep_schema_and_table(table_name, schema)
 
-    if schema != 'experimental':
+    if schema == 'curated':
         check_for_comments(table_comment, df.columns, col_comments)
         if not os.getenv('HC_PROD_ENV'):
             raise ValueError(


### PR DESCRIPTION
After a discussion with Max and seeing how yall have used the lake so far, it is clear that you'll be working with the staging zone a lot more than I originally anticipated. So, I am unblocking overwriting in the landing and staging zones (although I doubt yall will be messing with the landing zone much at all) in order to make sure your work doesn't get blocked on a rather arbitrary rule like that. Additionally, this removes the requirement of table/column comments for those zones - it just seems like an unnecessary hinderance to require documentation on the tables in there, now that I'm seeing what the usage of these zones actually looks like in practice. Let me know if this sounds alright to you!