### PR TITLE
CTAS Self-Overwrite Bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Bugfix: CTAS can now overwrite a table that it is selecting from. Previously,
+if CTAS was used to overwrite a table that was in the select statement,
+the data from that source table would not be in the resulting table
+
 ## [1.5.2] - 2021-01-22
 
 ### Changed

--- a/honeycomb/create_table.py
+++ b/honeycomb/create_table.py
@@ -409,7 +409,6 @@ def ctas(select_stmt, table_name, schema=None,
             __nuke_table(source_table_name, schema)
 
 
-
 def flash_update_table_from_df(df, table_name, schema=None, dtypes=None,
                                table_comment=None, col_comments=None,
                                timezones=None, copy_df=True):

--- a/honeycomb/create_table.py
+++ b/honeycomb/create_table.py
@@ -338,15 +338,22 @@ def ctas(select_stmt, table_name, schema=None,
 
     table_rename_template = 'ALTER TABLE {}.{} RENAME TO {}.{}'
     if '{}.{}'.format(schema, table_name) in select_stmt:
-        source_table_name = table_name + '_temp_ctas_rename'
-        select_stmt = select_stmt.replace(
-            '{}.{}'.format(schema, table_name),
-            '{}.{}'.format(schema, source_table_name)
-        )
-        hive.run_lake_query(table_rename_template.format(
-            schema, table_name, schema, source_table_name
-        ))
-        table_renamed = True
+        if overwrite:
+            source_table_name = table_name + '_temp_ctas_rename'
+            select_stmt = select_stmt.replace(
+                '{}.{}'.format(schema, table_name),
+                '{}.{}'.format(schema, source_table_name)
+            )
+            hive.run_lake_query(table_rename_template.format(
+                schema, table_name, schema, source_table_name
+            ))
+            table_renamed = True
+        else:
+            raise ValueError(
+                'CTAS functionality must have \'overwrite\' set to True '
+                'in order to overwrite one of the source tables of the '
+                'SELECT statement.'
+            )
     else:
         source_table_name = table_name
         table_renamed = False


### PR DESCRIPTION
Thanks for finding this @freytheviking! Fun fact: This is my first ever actual use of a full `try, else, finally` block.

- Bugfix: CTAS can now overwrite a table that it is selecting from. Previously,
if CTAS was used to overwrite a table that was in the select statement,
the data from that source table would not be in the resulting table