### PR TITLE
v1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.3] 2021-02-12
+
 ### Added
 - Session-level configuration Functionality
 - Verbosity option: disable all non-logging output, for use in notebooks or pipelines.

--- a/honeycomb/_version.py
+++ b/honeycomb/_version.py
@@ -1,6 +1,6 @@
 __title__ = "honeycomb"
 __description__ = "Multi-source/engine querying tool"
 __url__ = "https://github.com/neighborhoods/honeycomb"
-__version__ = "1.5.2"
+__version__ = "1.5.3"
 __author__ = "George Wood (@Geoiv)"
 __author_email__ = "george.wood@55places.com"


### PR DESCRIPTION
Total changes for this version:
### Added
- Session-level configuration Functionality
- Verbosity option: disable all non-logging output, for use in notebooks or pipelines.

### Changed
- Bugfix: CTAS can now overwrite a table that it is selecting from. Previously,
if CTAS was used to overwrite a table that was in the select statement,
the data from that source table would not be in the resulting table
- `pd.io.sql.DatabaseError`s will now be raised properly when raised in an un-handleable
way from within `_hive_query`
- Column comments in Avro tables are now injected into the Avro schema, so they will
properly be added to a Hive metastore.