### PR TITLE
DE-241 | Pandas 1.0 Type Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support for Pandas v1.0+ nullable integer, nullable string, and nullable boolean types
+
 ### Changed
 - Column comments will now be properly added to the Avro schema in struct fields
 nested within arrays

--- a/honeycomb/dtype_mapping.py
+++ b/honeycomb/dtype_mapping.py
@@ -20,6 +20,17 @@ dtype_map = {
     'float64': 'DOUBLE',
     'bool': 'BOOLEAN',
     'datetime64[ns]': 'TIMESTAMP',
+    # Pandas 1.0 types
+    'string': 'STRING',
+    'Int8': 'BIGINT',
+    'Int16': 'BIGINT',
+    'Int32': 'BIGINT',
+    'Int64': 'BIGINT',
+    'UInt8': 'BIGINT',
+    'UInt16': 'BIGINT',
+    'UInt32': 'BIGINT',
+    'UInt64': 'BIGINT',
+    'boolean': 'BOOLEAN'
 }
 
 
@@ -157,6 +168,18 @@ def map_pd_to_db_dtypes(df, storage_type=None):
     if any(df.dtypes == 'timedelta64[ns]'):
         raise TypeError('Pandas\' \'timedelta64[ns]\' type is not supported. '
                         'Contact honeycomb devs for further info.')
+
+    # These refer to the pandas v1.0 dtypes, NOT the base Python types
+    avro_disallowed_types = ['string', 'boolean']
+
+    pd_v1_type_cols = df.columns[
+        df.dtypes.astype(str).isin(avro_disallowed_types)]
+    if storage_type == 'avro' and len(pd_v1_type_cols) > 0:
+        raise TypeError(
+            'The following columns are using Pandas v1.0 nullable-string '
+            'or nullable-boolean dtypes, which are currently not supported '
+            'when using the avro filetype.'
+        )
     db_dtypes = df.dtypes.copy()
 
     for orig_type, new_type in dtype_map.items():

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -69,6 +69,46 @@ def test_df_all_types():
 
 
 @pytest.fixture
+def test_df_pdv1_types():
+    pdv1_test_mapping = {
+        'int8col': {
+            'vals': [1, 2, 3],
+            'pd_type': pd.Int8Dtype()
+        },
+        'int16col': {
+            'vals': [1, 2, 3],
+            'pd_type': pd.Int16Dtype()
+        },
+        'int32col': {
+            'vals': [1, 2, 3],
+            'pd_type': pd.Int32Dtype()
+        },
+        'int64col': {
+            'vals': [1, 2, 3],
+            'pd_type': pd.Int64Dtype()
+        },
+        'stringcol': {
+            'vals': ['one', 'two', 'three'],
+            'pd_type': pd.StringDtype()
+        },
+        'boolcol': {
+            'vals': [True, False, True],
+            'pd_type': pd.BooleanDtype()
+        }
+    }
+    pdv1_df = pd.DataFrame({
+        col_name: col_meta['vals']
+        for col_name, col_meta in pdv1_test_mapping.items()
+    })
+
+    pdv1_df = pdv1_df.astype({
+        col_name: col_meta['pd_type']
+        for col_name, col_meta in pdv1_test_mapping.items()
+    })
+    return pdv1_df
+
+
+@pytest.fixture
 def mock_s3_client():
     """Mocks all s3 connections in any test or fixture that includes it"""
     with mock_s3():

--- a/test/test_dtype_mapping.py
+++ b/test/test_dtype_mapping.py
@@ -42,6 +42,22 @@ def test_map_pd_to_db_dtypes_unsupported_fails():
         map_pd_to_db_dtypes(td_df, storage_type='csv')
 
 
+def test_map_pd_to_db_dtypes_pdv1_types(test_df_pdv1_types):
+    expected_dtypes = pd.DataFrame({
+        'col_name': ['int8col', 'int16col', 'int32col', 'int64col',
+                     'stringcol', 'boolcol'],
+        'dtype': ['BIGINT', 'BIGINT', 'BIGINT', 'BIGINT', 'STRING', 'BOOLEAN']
+    })
+
+    mapped_dtypes = map_pd_to_db_dtypes(test_df_pdv1_types, storage_type='csv')
+    assert mapped_dtypes.equals(expected_dtypes)
+
+
+def test_avro_disallows_pdv1_types(test_df_pdv1_types):
+    with pytest.raises(TypeError, match=r'using Pandas v1.0.* not supported'):
+        map_pd_to_db_dtypes(test_df_pdv1_types, storage_type='avro')
+
+
 def test_apply_spec_dtypes(test_df_all_types):
     """
     Tests that applying specified dtypes behaves as expected under


### PR DESCRIPTION
### Added
- Support for Pandas v1.0+ nullable integer, nullable string, and nullable boolean types