### PR TITLE
v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.2] 2021-05-24
+
+### Changed
+- ORC operations now allow for source tables that make use of Hive reserved
+words as column names. While using these reserved words this way is discouraged,
+there are times where the column names of source tables cannot feasibly be
+controlled.
+
 ## [1.6.1] 2021-05-13
 
 ### Added

--- a/honeycomb/_version.py
+++ b/honeycomb/_version.py
@@ -1,6 +1,6 @@
 __title__ = "honeycomb"
 __description__ = "Multi-source/engine querying tool"
 __url__ = "https://github.com/neighborhoods/honeycomb"
-__version__ = "1.6.1"
+__version__ = "1.6.2"
 __author__ = "George Wood (@Geoiv)"
 __author_email__ = "george.wood@55places.com"


### PR DESCRIPTION
### Changed
- ORC operations now allow for source tables that make use of Hive reserved
words as column names. While using these reserved words this way is discouraged,
there are times where the column names of source tables cannot feasibly be
controlled.